### PR TITLE
fix: copy options object before assigning suffix

### DIFF
--- a/src/core/mapped-exception.class.ts
+++ b/src/core/mapped-exception.class.ts
@@ -8,7 +8,7 @@ export class MappedException<T> {
   private options: MappedExceptionOptions;
 
   constructor(exception: any, options: MappedExceptionOptions) {
-    this.options = options;
+    this.options = {...options};
 
     let instance = new exception();
 


### PR DESCRIPTION
This fix a problem where every exception class was receiving the same suffix as the first.